### PR TITLE
Fix Intellisense errors

### DIFF
--- a/project.hxp
+++ b/project.hxp
@@ -50,7 +50,6 @@ class Project extends HXProject
 	public function new()
 	{
 		super();
-		haxedefs.set("FUNKIN_GIT_DETAILS", "");
 		setenv('HAXEPATH', './'); // Fixes an issue for haxelibs that use native C++ files until Haxe 5 releases.
 
 		setupApplicationSettings();

--- a/project.hxp
+++ b/project.hxp
@@ -50,7 +50,7 @@ class Project extends HXProject
 	public function new()
 	{
 		super();
-
+		haxedefs.set("FUNKIN_GIT_DETAILS", "");
 		setenv('HAXEPATH', './'); // Fixes an issue for haxelibs that use native C++ files until Haxe 5 releases.
 
 		setupApplicationSettings();

--- a/src/funkin/Constants.hx
+++ b/src/funkin/Constants.hx
@@ -1,6 +1,8 @@
 package funkin;
 
+#if FUNKIN_GIT_DETAILS
 import funkin.macros.GitDefines;
+#end
 
 class Constants
 {
@@ -14,6 +16,7 @@ class Constants
    */
   public static final FNF_VERSION:String = '0.8.1';
 
+  #if FUNKIN_GIT_DETAILS
   /**
    * The current Git Commit Hash.
    */
@@ -33,6 +36,7 @@ class Constants
    * If there is local changes to the git branch.
    */
   public static final GIT_MODIFIED:Bool = GitDefines.gitModified();
+  #end
 
   /**
    * Default Difficulties

--- a/src/funkin/macros/FunkinMacroCache.hx
+++ b/src/funkin/macros/FunkinMacroCache.hx
@@ -5,10 +5,10 @@ import haxe.Unserializer;
 import haxe.ds.StringMap;
 import haxe.macro.Context;
 import haxe.macro.Expr;
+#if macro
 import sys.FileSystem;
 import sys.io.File;
 
-#if macro
 /**
  * Pretty much a save file for macros.
  * Lets you keep values for later compiles.

--- a/src/funkin/macros/FunkinMacroCache.hx
+++ b/src/funkin/macros/FunkinMacroCache.hx
@@ -1,11 +1,11 @@
 package funkin.macros;
 
+#if macro
 import haxe.Serializer;
 import haxe.Unserializer;
 import haxe.ds.StringMap;
 import haxe.macro.Context;
 import haxe.macro.Expr;
-#if macro
 import sys.FileSystem;
 import sys.io.File;
 

--- a/src/funkin/macros/GitDefines.hx
+++ b/src/funkin/macros/GitDefines.hx
@@ -1,6 +1,6 @@
 package funkin.macros;
 
-#if (FUNKIN_GIT_DETAILS || display)
+#if FUNKIN_GIT_DETAILS
 import haxe.macro.Context;
 import haxe.macro.Expr;
 

--- a/src/funkin/macros/GitDefines.hx
+++ b/src/funkin/macros/GitDefines.hx
@@ -1,6 +1,6 @@
 package funkin.macros;
 
-#if FUNKIN_GIT_DETAILS
+#if (FUNKIN_GIT_DETAILS || display)
 import haxe.macro.Context;
 import haxe.macro.Expr;
 


### PR DESCRIPTION
Everytime I try to restart the Haxe language server to build cache, i end up with these errors:

```
Haxe language server started
Haxe Path: haxe.exe
Using --server-connect
Haxe connected!
Listening on port 127.0.0.1:6000
Failed - try fixing the error(s) and restarting the language server:

[ERROR] src/funkin/macros/FunkinMacroCache.hx:8: characters 8-22

 8 | import sys.FileSystem;
   |        ^^^^^^^^^^^^^^
   | You cannot access the sys package while targeting js (for sys.FileSystem)
[RefactorCache] detected classpaths: [src/]
```

```
Haxe language server started
Haxe Path: haxe.exe
Using --server-connect
Haxe connected!
Listening on port 127.0.0.1:6000
Failed - try fixing the error(s) and restarting the language server:

[ERROR] src/funkin/Constants.hx:20: characters 41-51

 20 |   public static final GIT_HASH:String = GitDefines.gitCommitHash();
    |                                         ^^^^^^^^^^
    | Type not found : GitDefines
[RefactorCache] detected classpaths: [src/]
```

This pull request simply fixes these